### PR TITLE
Add x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Agent Skills work with these AI coding agents:
 | **[analytics-metrics](skills/analytics-metrics/SKILL.md)** | Data visualization and analytics dashboards | `analytics`, `dashboard`, `charts`, `KPI` |
 | **[mermaid-diagrams](skills/mermaid-diagrams/SKILL.md)** | Mermaid diagram syntax for visualizations | `Mermaid`, `flowchart`, `sequence diagram` |
 | **[local-llm-router](skills/local-llm-router/SKILL.md)** | Route queries to local LLMs in air-gapped networks with Serena MCP | `local LLM`, `Ollama`, `LM Studio`, `air-gapped`, `Serena`, `model routing` |
+| **[x-twitter-scraper](skills/x-twitter-scraper/SKILL.md)** | X/Twitter data extraction — tweet search, user lookup, followers, media, monitoring | `Twitter`, `X`, `scraper`, `OSINT`, `tweets`, `followers` |
 
 ---
 
@@ -588,10 +589,12 @@ ai-agents-skills/
 │   │   └── 📄 SKILL.md
 │   ├── 📁 mermaid-diagrams/
 │   │   └── 📄 SKILL.md
-│   └── 📁 local-llm-router/
-│       ├── 📄 SKILL.md
-│       └── 📁 references/
-│           └── 📄 model-matrix.md
+│   ├── 📁 local-llm-router/
+│   │   ├── 📄 SKILL.md
+│   │   └── 📁 references/
+│   │       └── 📄 model-matrix.md
+│   └── 📁 x-twitter-scraper/
+│       └── 📄 SKILL.md
 └── 📁 templates/
     └── 📁 skill-template/
         └── 📄 SKILL.md

--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: x-twitter-scraper
+description: X (Twitter) data extraction and scraping. Use when asked to scrape tweets, extract followers, search Twitter/X users, download media from tweets, monitor X accounts, or analyze Twitter engagement. Triggers on twitter, x.com, tweet, follower, following, retweet, quote tweet, scrape, OSINT.
+---
+
+# X/Twitter Scraper
+
+AI agent skill for X (Twitter) data extraction — tweet search, user lookup, follower/following lists, media download, reply/retweet/quote extraction, account monitoring, and trending topics.
+
+## Quick Start
+
+Install as a Claude Code skill:
+
+```bash
+# Copy to your project
+cp -r skills/x-twitter-scraper .claude/skills/
+
+# Or for GitHub Copilot
+cp -r skills/x-twitter-scraper .github/skills/
+```
+
+Visit [x-twitter-scraper on GitHub](https://github.com/Xquik-dev/x-twitter-scraper) for full setup instructions.
+
+## Core Capabilities
+
+### Tweet Search
+```
+Search tweets by keyword, hashtag, or advanced query with date filters and result limits.
+```
+
+### User Lookup
+```
+Get user profile data: bio, follower/following counts, verification status, account age.
+```
+
+### Follower & Following Extraction
+```
+Bulk extract follower and following lists for any public account.
+```
+
+### Reply, Retweet & Quote Extraction
+```
+Extract all replies, retweets, or quote tweets from a specific tweet.
+```
+
+### Media Download
+```
+Download images and videos from tweets.
+```
+
+### Account Monitoring
+```
+Set up real-time monitoring for account activity changes.
+```
+
+### Trending Topics
+```
+Get trending topics by location.
+```
+
+## Common Use Cases
+
+### OSINT Research
+```
+Look up a Twitter user, extract their followers, and analyze engagement patterns.
+```
+
+### Giveaway Management
+```
+Search for giveaway tweets, extract participants (replies, retweets, quotes), and run draws.
+```
+
+### Competitive Analysis
+```
+Monitor competitor accounts, track follower growth, and extract engagement data.
+```
+
+## Integration
+
+- **MCP Server**: Port 3100, API key auth, 20 tools
+- **REST API**: `/api/v1/*` endpoints with HMAC webhooks
+- **Agent Skill**: SKILL.md format for Claude Code, Copilot, Cursor, Windsurf
+
+## Resources
+
+- **GitHub**: https://github.com/Xquik-dev/x-twitter-scraper
+- **Platform**: https://xquik.com

--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -13,9 +13,11 @@ Install as a Claude Code skill:
 
 ```bash
 # Copy to your project
+mkdir -p .claude/skills
 cp -r skills/x-twitter-scraper .claude/skills/
 
 # Or for GitHub Copilot
+mkdir -p .github/skills
 cp -r skills/x-twitter-scraper .github/skills/
 ```
 


### PR DESCRIPTION
Add the [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) skill to the collection.

**What it does:**
- X (Twitter) data extraction skill for AI coding agents
- Tweet search, user lookup, follower/following extraction, media download
- Reply, retweet, and quote tweet extraction
- Account monitoring and trending topics
- MCP server (port 3100), REST API, HMAC webhooks
- Works with Claude Code, Copilot, Cursor, Windsurf, and 40+ agents

**Changes:**
- Added `skills/x-twitter-scraper/SKILL.md` following the repo's skill template format
- Updated README.md skills table and directory structure

I am the developer of Xquik.